### PR TITLE
Ready event doesn't get cleared after first execution

### DIFF
--- a/src/Ubidots.js
+++ b/src/Ubidots.js
@@ -117,7 +117,7 @@ class Ubidots {
 
     if (this._token !== undefined && this._selectedDevice !== undefined && this._dashboardDateRange !== undefined && typeof this._eventsCallback.ready === 'function') {
       this._eventsCallback.ready();
-      this._eventsCallback.ready === null;
+      this._eventsCallback.ready = null;
     }
   }
 }

--- a/tests/Ubidots.test.js
+++ b/tests/Ubidots.test.js
@@ -195,5 +195,73 @@ describe('Array', () => {
       expect(spy.notCalled).to.be.ok();
       expect(obj.dashboardDateRange).to.be(selectedDashboardDateRange);
     });
+
+    it('should not execute the ready event if the previous values are not yet set', () => {
+      const ubidots = setUp();
+      global.window = { location: { origin: 'http://127.0.0.1' } };
+
+      const spy = sinon.spy();
+      ubidots.on('ready', spy);
+
+      const event = {
+        origin: 'http://127.0.0.1',
+        data: {
+          event: 'receivedToken',
+          payload: 'test-token',
+        },
+      };
+      ubidots._listenMessage(event);
+
+      expect(spy.notCalled).to.be.ok();
+    });
+
+    it('should execute the ready event if the previous values are set', () => {
+      const ubidots = setUp();
+      global.window = { location: { origin: 'http://127.0.0.1' } };
+
+      const spy = sinon.spy();
+      ubidots.on('ready', spy);
+
+      ubidots._token = 'prefilled-token';
+      ubidots._selectedDevice = 'prefilled-device';
+      ubidots._dashboardDateRange = 'prefilled-date';
+
+      const event = {
+        origin: 'http://127.0.0.1',
+        data: {
+          event: 'receivedToken',
+          payload: 'test-token',
+        },
+      };
+      ubidots._listenMessage(event);
+
+      expect(spy.called).to.be.ok();
+    });
+
+    it('should execute the ready event only once in the lifetime', () => {
+      const ubidots = setUp();
+      global.window = { location: { origin: 'http://127.0.0.1' } };
+
+      const spy = sinon.spy();
+      ubidots.on('ready', spy);
+
+      ubidots._token = 'prefilled-token';
+      ubidots._selectedDevice = 'prefilled-device';
+      ubidots._dashboardDateRange = 'prefilled-date';
+
+      const event = {
+        origin: 'http://127.0.0.1',
+        data: {
+          event: 'receivedToken',
+          payload: 'test-token',
+        },
+      };
+
+      for (let i = 0; i < 50; i++) {
+        ubidots._listenMessage(event);
+      }
+
+      expect(spy.calledOnce).to.be.ok();
+    });
   });
 });


### PR DESCRIPTION
The expected behavior is that the ready function only gets executed once
and then its listener gets cleared from the library after it is
executed.

The current code instead of making a declaration to null its doing a
comparation to null.

This commit changes the behavior of the library for the ready event.