### PR TITLE
:sparkles: [SD-4639] feat: emit receivedHeaders event

### DIFF
--- a/src/Ubidots.js
+++ b/src/Ubidots.js
@@ -20,6 +20,15 @@ class Ubidots {
     window.addEventListener("message", this._listenMessage);
   }
 
+  _emitReceivedHeaders() {
+    const event = {
+      data: { event: "receivedHeaders", payload: this.getHeaders() },
+      origin: window.location.origin,
+    };
+
+    this._listenMessage(event);
+  }
+
   /**
    * Send a post Message
    * @param {Object}
@@ -94,10 +103,12 @@ class Ubidots {
    */
   _setToken = (token) => {
     this._token = token;
+    this._emitReceivedHeaders();
   };
 
   _setJWTToken = (jwt) => {
     this._jwtToken = jwt;
+    this._emitReceivedHeaders();
   };
 
   _setHeaders = (headers = {}) => {

--- a/tests/Ubidots.test.js
+++ b/tests/Ubidots.test.js
@@ -403,4 +403,44 @@ describe("Array", () => {
       expect(obj.dashboardObject).to.be(dashboardObject);
     });
   });
+
+  describe("#_emitReceivedHeaders", () => {
+    it("should be called when the token changes", () => {
+      global.window = {
+        location: { origin: "http://127.0.0.1" },
+        addEventListener: sinon.spy(),
+      };
+
+      const ubidots = setUp();
+      const spy = sinon.fake();
+      ubidots.on("receivedHeaders", spy);
+
+      const event = {
+        data: { event: "receivedToken", payload: "a1n2g3e4l5o" },
+        origin: "http://127.0.0.1",
+      };
+
+      ubidots._listenMessage(event);
+      expect(spy.calledWith(ubidots.getHeaders())).to.be.ok();
+    });
+
+    it("should be called when jwt changes", () => {
+      global.window = {
+        location: { origin: "http://127.0.0.1" },
+        addEventListener: sinon.spy(),
+      };
+
+      const ubidots = setUp();
+      const spy = sinon.fake();
+      ubidots.on("receivedHeaders", spy);
+
+      const event = {
+        data: { event: "receivedJWTToken", payload: "a1n2g3e4l5o" },
+        origin: "http://127.0.0.1",
+      };
+
+      ubidots._listenMessage(event);
+      expect(spy.calledWith(ubidots.getHeaders())).to.be.ok();
+    });
+  });
 });


### PR DESCRIPTION
* Este evento debe emitirse cuando se genera algún cambio en los tokens (x-auth-token o jwt).